### PR TITLE
Sprite compatibility with thumbyGraphics

### DIFF
--- a/tests/EnduranceTest.py
+++ b/tests/EnduranceTest.py
@@ -32,8 +32,7 @@ def legacySprite(spr):
     # 1 0 -> 0 1 # Dark gray
     # 0 1 -> 1 1 # Light gray
     # 1 1 -> 1 0 # White
-    b1 = spr.bitmap
-    b2 = spr.bitmapSHD
+    b1, b2 = spr.layers
     for i in range(0, len(b1)):
         a1 = b1[i]
         a2 = b2[i]

--- a/tests/FastTest.py
+++ b/tests/FastTest.py
@@ -42,8 +42,7 @@ def legacy_sprite(spr):
     # 1 0 -> 0 1 # Dark gray
     # 0 1 -> 1 1 # Light gray
     # 1 1 -> 1 0 # White
-    b1 = spr.bitmap
-    b2 = spr.bitmapSHD
+    b1, b2 = spr.layers
     for i in range(0, len(b1)):
         a1 = b1[i]
         a2 = b2[i]


### PR DESCRIPTION
Grayscale Sprites backwards compatible enough to be passed to thumbyGraphics methods to show the black and white equivalent.

Removal of the ability to pass a tuple containing both bitmap layers to the mask parameter of blitWithMask. This didn't make much sense on its own and was previously used to
enable compatibility with supporting black and white Sprites, but these changes make this unneccessary.