### PR TITLE
Fix bugs in drawFilledRectangle and blitWithMask

### DIFF
--- a/lib/thumbyGrayscale.py
+++ b/lib/thumbyGrayscale.py
@@ -693,7 +693,8 @@ class Grayscale:
 
     @micropython.viper
     def drawFilledRectangle(self, x:int, y:int, width:int, height:int, colour:int):
-        if x >= _WIDTH or y >= _HEIGHT: return
+        if x + width <= 0 or x >= _WIDTH or y + height <= 0 or y >= _HEIGHT:
+            return
         if width <= 0 or height <= 0: return
         if x < 0:
             width += x

--- a/lib/thumbyGrayscale.py
+++ b/lib/thumbyGrayscale.py
@@ -1123,7 +1123,7 @@ class Grayscale:
             dstco = dsto
             i = width
             while i != 0:
-                if (maskp[srcco] & srcm) == 0:
+                if maskp[srcco] & srcm:
                     if src1[srcco] & srcm:
                         buffer[dstco] |= dstm
                     else:


### PR DESCRIPTION
`drawFilledRectangle`: the bounds tests were insufficient, causing artifacts for rectangles that were entirely above the top of the screen
`blitWithMask`: the logic was interpreting 0 bits in the mask as opaque (should draw to the pixel), vs. 1 for opaque in `thumbyDisplay`'s implementation