### PR TITLE
Fix the config reload crash that affects a small percentage of Thumbys.

### DIFF
--- a/lib/thumbyGrayscale.py
+++ b/lib/thumbyGrayscale.py
@@ -21,11 +21,12 @@ import _thread
 from os import stat
 from math import sqrt, floor
 from array import array
+from thumbyAudio import audio
 from thumbyButton import buttonA, buttonB, buttonU, buttonD, buttonL, buttonR
 from thumbyHardware import HWID
 from sys import modules
 
-__version__ = '4.0.2-hemlock'
+__version__ = '4.0.3'
 
 
 emulator = None
@@ -275,6 +276,7 @@ class Grayscale:
         if not emulator:
             try:
                 with open("thumbyGS.cfg", "r") as fh:
+                    audio.playBlocking(11,11) # Fix rare config load crash (PF).
                     vls = fh.read().split('\n')
                     for fhd in vls:
                         if fhd.startswith('gsV3,'):


### PR DESCRIPTION
These thumbys would work correctly with grayscale until the calibration config is loaded on a second run. Grayscale would then never load correctly until the config file is deleted and it is calibrated again.

This emission of a short inaudible burst of audio seems to fix the issue. I have no idea why. But it does, for all affected Thumbys: https://discord.com/channels/898292107289190461/898292174410612787/1299077610025783317 https://discord.com/channels/898292107289190461/898292174410612787/1299091476239614155 https://discord.com/channels/898292107289190461/996871099499425873/1256231698098688052 Maybe it's a timing issue on loading config files. Maybe it is that the flash isn't initialised properly at that point. Maybe the audio burst, gives the flash a little nudge to shake it awake. I don't know, but until I have access to an affected Thumby, or until someone wants to golf this, this will have to do.

Thanks to PF (@htmlgames from the Discord channel) for this magic fix!